### PR TITLE
Fix compilation error

### DIFF
--- a/src/clj_webjars.clj
+++ b/src/clj_webjars.clj
@@ -29,7 +29,7 @@
        java.util.Date.))
 
 (defn- date-as-string [^java.util.Date date]
-  (.format (file-info/make-http-format) date))
+  (.format (#'file-info/make-http-format) date))
 
 (defn- input-stream-to-array [is]
   (let [os (java.io.ByteArrayOutputStream.)]


### PR DESCRIPTION
file-info/make-http-format is now private:

> Exception in thread "main" java.lang.IllegalStateException: var: #'ring.middleware.file-info/make-http-format is not public, compiling:(clj_webjars.clj:41:12)

Not sure accessing private vars is the best way to go, but fixes things for now.
