### PR TITLE
Update clj_webjars.clj

### DIFF
--- a/src/clj_webjars.clj
+++ b/src/clj_webjars.clj
@@ -2,6 +2,7 @@
   (:require [clojure.java.io :as io]
             [clojure.string :refer [replace-first]]
             [ring.util.mime-type :refer [ext-mime-type]]
+            [ring.util.time :refer [format-date]]
             [ring.util.response :as response]
             [ring.middleware.file-info :as file-info])
   (:import [org.webjars WebJarAssetLocator]))
@@ -27,9 +28,6 @@
        java.io.File.
        .lastModified
        java.util.Date.))
-
-(defn- date-as-string [^java.util.Date date]
-  (.format (#'file-info/make-http-format) date))
 
 (defn- input-stream-to-array [is]
   (let [os (java.io.ByteArrayOutputStream.)]
@@ -60,7 +58,7 @@
 
 (defn- response-modified [uri stream date]
   (-> (response/response stream)
-      (response/header "Last-Modified" (date-as-string date))
+      (response/header "Last-Modified" (format-date date))
       (response/content-type (or (ext-mime-type uri) "application/octet-stream"))))
 
 (defn- response-multiple-matches [uri assets]


### PR DESCRIPTION
Can use ring.util.time/format-date instead of private make-http-format (see comment here https://github.com/ring-clojure/ring/commit/29064461e4e42c07224cbbc600a643bd85fd2f49#commitcomment-7300695)
